### PR TITLE
Use get_phantom_base_url instead of 127.0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ This table lists the configuration variables required to operate Switchboard. Th
 
 VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
-**https_port** | optional | string | Splunk SOAR HTTPS port if your instance uses one other than 443 |
 **repository_filter** | optional | string | A comma separated list of repositories that shouldn't be added to playbook cache |
 **cache_expiration** | required | numeric | How long should the playbook cache be valid in seconds |
 **debug** | optional | boolean | Print debugging statements to log |

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
-* Use build_phantom_rest_url instead of 127.0.0.1
+* Use get_phantom_base_url instead of 127.0.0.1

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,4 +1,3 @@
 **Unreleased**
 
-* chore(ci): update pre-commit config
 * Use get_phantom_base_url instead of 127.0.0.1

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * chore(ci): update pre-commit config
+* Use build_phantom_rest_url instead of 127.0.0.1

--- a/switchboard.json
+++ b/switchboard.json
@@ -145,11 +145,5 @@
             "output": [],
             "versions": "EQ(*)"
         }
-    ],
-    "custom_made": true,
-    "directory": "switchboard_24aceaea-6bb2-4888-a3dc-5ef28ccb086a",
-    "version": 1,
-    "appname": "-",
-    "executable": "spawn3",
-    "disabled": false
+    ]
 }

--- a/switchboard.json
+++ b/switchboard.json
@@ -23,36 +23,29 @@
         }
     ],
     "configuration": {
-        "https_port": {
-            "description": "Splunk SOAR HTTPS port if your instance uses one other than 443",
-            "data_type": "string",
-            "order": 0,
-            "name": "https_port",
-            "id": 0
-        },
         "repository_filter": {
             "description": "A comma separated list of repositories that shouldn't be added to playbook cache",
             "data_type": "string",
-            "order": 1,
+            "order": 0,
             "name": "repository_filter",
-            "id": 1
+            "id": 0
         },
         "cache_expiration": {
             "description": "How long should the playbook cache be valid in seconds",
             "data_type": "numeric",
             "required": true,
             "default": "600",
-            "order": 2,
+            "order": 1,
             "name": "cache_expiration",
-            "id": 2
+            "id": 1
         },
         "debug": {
             "description": "Print debugging statements to log",
             "data_type": "boolean",
             "default": "False",
-            "order": 3,
+            "order": 2,
             "name": "debug",
-            "id": 3
+            "id": 2
         }
     },
     "actions": [

--- a/switchboard_connector.py
+++ b/switchboard_connector.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 import datetime
 import json
+import urllib.parse
 
 import phantom.app as phantom
+import phantom.rules as phrules
 from phantom.action_result import ActionResult
 
 
@@ -79,12 +81,9 @@ class SwitchboardConnector(phantom.BaseConnector):
 
     def _get_base_url(self):
         self.__print("_get_base_url()", True)
-        port = 443
-        try:
-            port = self.get_config()["https_port"]
-        except:
-            pass
-        return f"https://127.0.0.1:{port}"
+        rest_url = phrules.build_phantom_rest_url()
+        scheme, netloc, _, _, _ = urllib.parse.urlsplit(rest_url)
+        return urllib.parse.urlunsplit((scheme, netloc, '', '', ''))
 
     def _get_repository_id(self, scm):
         self.__print(f"Start: _get_repository_id(): {datetime.datetime.now()}", True)

--- a/switchboard_connector.py
+++ b/switchboard_connector.py
@@ -13,10 +13,8 @@
 # limitations under the License.
 import datetime
 import json
-import urllib.parse
 
 import phantom.app as phantom
-import phantom.rules as phrules
 from phantom.action_result import ActionResult
 
 
@@ -81,9 +79,7 @@ class SwitchboardConnector(phantom.BaseConnector):
 
     def _get_base_url(self):
         self.__print("_get_base_url()", True)
-        rest_url = phrules.build_phantom_rest_url()
-        scheme, netloc, _, _, _ = urllib.parse.urlsplit(rest_url)
-        return urllib.parse.urlunsplit((scheme, netloc, "", "", ""))
+        return self.get_phantom_base_url()
 
     def _get_repository_id(self, scm):
         self.__print(f"Start: _get_repository_id(): {datetime.datetime.now()}", True)

--- a/switchboard_connector.py
+++ b/switchboard_connector.py
@@ -83,7 +83,7 @@ class SwitchboardConnector(phantom.BaseConnector):
         self.__print("_get_base_url()", True)
         rest_url = phrules.build_phantom_rest_url()
         scheme, netloc, _, _, _ = urllib.parse.urlsplit(rest_url)
-        return urllib.parse.urlunsplit((scheme, netloc, '', '', ''))
+        return urllib.parse.urlunsplit((scheme, netloc, "", "", ""))
 
     def _get_repository_id(self, scm):
         self.__print(f"Start: _get_repository_id(): {datetime.datetime.now()}", True)


### PR DESCRIPTION
### Bug Fixes
- Fixes SOARHELP-4542 by removing the hard-coded 127.0.0.1

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
